### PR TITLE
Making clear static usage of helpers

### DIFF
--- a/src/API/Simulation/Simulation.cpp
+++ b/src/API/Simulation/Simulation.cpp
@@ -43,8 +43,7 @@ main(int argc, char** argv)
 		return 1;
 	}
 
-	SimulationHelper helper;
-	Aggregator aggregator = helper.createAggregation(argv[1]);
+	Aggregator aggregator = SimulationHelper::createAggregation(argv[1]);
 	SimpleRunner run(aggregator);
 
 	if (run.runAllStages())

--- a/src/FlightAnalysis/FlightAnalysis.cpp
+++ b/src/FlightAnalysis/FlightAnalysis.cpp
@@ -31,7 +31,6 @@ int
 main(int argc, char** argv)
 {
 	std::string configPath;
-	FlightAnalysisHelper helper;
 	SynchronizedRunner runner;
 
 	APLogger::instance()->setLogLevel(LogLevel::WARN);
@@ -42,7 +41,7 @@ main(int argc, char** argv)
 		configPath = argv[1];
 	}
 
-	Aggregator aggregator = helper.createAggregation(configPath);
+	Aggregator aggregator = FlightAnalysisHelper::createAggregation(configPath);
 	auto sched = aggregator.getOne<IScheduler>();
 	sched->setMainThread();
 

--- a/src/FlightControl/FlightControl.cpp
+++ b/src/FlightControl/FlightControl.cpp
@@ -32,8 +32,7 @@ main(int argc, char** argv)
 		return 0;
 	}
 
-	FlightControlHelper helper;
-	Aggregator aggregator = helper.createAggregation(configPath);
+	Aggregator aggregator = FlightControlHelper::createAggregation(configPath);
 	auto sched = aggregator.getOne<IScheduler>();
 	sched->setMainThread();
 

--- a/src/Tools/EmulationInterface/education/main.cpp
+++ b/src/Tools/EmulationInterface/education/main.cpp
@@ -45,9 +45,7 @@ main(int argc, char** argv)
 		configPath = "/usr/local/config/edu.json";
 	}
 
-	EduInterfaceHelper helper;
-
-	auto agg = helper.createAggregation(configPath);
+	auto agg = EduInterfaceHelper::createAggregation(configPath);
 
 	auto sched = agg.getOne<IScheduler>();
 	sched->setMainThread();

--- a/src/Tools/EmulationInterface/uavap/EmulationInterface.cpp
+++ b/src/Tools/EmulationInterface/uavap/EmulationInterface.cpp
@@ -42,9 +42,7 @@ main(int argc, char** argv)
 		return 1;
 	}
 
-	EmulationInterfaceHelper helper;
-
-	auto agg = helper.createAggregation(configPath);
+	auto agg = EmulationInterfaceHelper::createAggregation(configPath);
 
 	auto sched = agg.getOne<IScheduler>();
 	sched->setMainThread();


### PR DESCRIPTION
Helpers are static, and 'initializing' them in an OO oriented manner is highly confusing. I understand most of the files modified in this commit are not used, but this change should still be there for visibility (I ran a grep to find all OO usages of the helper)